### PR TITLE
Improve _makechunks heruistic

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,15 @@
 function _makechunks(x::AbstractVector, n::Integer; overlap::Integer = 0)
-    c = length(x) ÷ n
-    chunks = [x[(1 + c * k):(k == n - 1 ? end : c * k + c)] for k in 0:(n - 1)]
+    total = length(x)
+    base = total ÷ n
+    extra = total % n
+    sizes = vcat(fill(base + 1, extra), fill(base, n - extra))
+    chunks = Vector{typeof(x)}(undef, n)
+    start = 1
+    for i in 1:n
+        stop = start + sizes[i] - 1
+        chunks[i] = x[start:stop]
+        start = stop + 1
+    end
     overlap == 0 && return chunks
     for i in 1:(length(chunks) - 1)
         chunks[i] = vcat(chunks[i], chunks[i + 1][1:overlap])

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -7,7 +7,8 @@ end
 Split the measurements in the measurement table into `n` chunks based on unique time points.
 
 The resulting chunking is applied to each simulation condition. If the number of unique time
-points is not divisible by `n`, the last chunk contains the remaining time points.
+points is not divisible by `n`, chunk sizes differ by at most one time point, with earlier
+chunks containing the additional points.
 """
 SplitTime(n::T) where {T <: Integer} = SplitTime{T}(n)
 """
@@ -32,7 +33,8 @@ end
 Splits the time-sorted measurements into `n` chunks (uniform by number of data points).
 
 The resulting chunking is applied to each simulation condition. If the number of data points
-is not divisible by `n`, the last chunk contains the remaining data points.
+is not divisible by `n`, chunk sizes differ by at most one data point, with earlier chunks
+containing the additional points.
 
 If all measurements have a unique time point, this is equivalent to `SplitTime(n)`.
 """

--- a/test/common.jl
+++ b/test/common.jl
@@ -48,16 +48,11 @@ function test_nllh(
 end
 
 function test_chunk_size(chunks)
-    n_stages = length(chunks)
     for i in 1:(length(chunks) - 1)
-        # Sometimes chunks cannot be divided uniformly, then the last is bigger
-        if i == length(chunks) - 1
-            @test abs(length(chunks[i]) - length(chunks[i + 1])) < n_stages
-        else
-            @test length(chunks[i]) == length(chunks[i + 1])
-        end
+        diff = abs(length(chunks[i]) - length(chunks[i + 1]))
+        @test diff ≤ 1
     end
-    return
+    return nothing
 end
 
 function _get_prob_duplicated(model_id, prob::PEtabODEProblem, ms_windows)

--- a/test/show.jl
+++ b/test/show.jl
@@ -23,29 +23,27 @@ prob_cl1 = PEtabClProblem(prob_original, SplitTime(3))
 model_id = "Bachmann_MSB2011"
 prob_original = _get_petab_problem(model_id)
 prob_cl2 = PEtabClProblem(prob_original, SplitTime(4))
-@test "$(describe(prob_cl1; as_string = true))" == "PEtabClProblem \
-    Boehm_JProteomeRes2014\nProblem statistics\n  Parameters to estimate: 9\n  ODE: 8 \
-    states, 10 parameters\n  Observables: 3\n  Simulation conditions: 1\n\nCurriculum \
-    statistics (3 stages)\n  Stage 1: tspan [0.0, 15.0]\n           fraction (obs/cond): \
-    1.0/1.0\n  Stage 2: tspan [0.0, 60.0]\n           fraction (obs/cond): 1.0/1.0\n  \
+@test "$(describe(prob_cl1; as_string = true))" == "PEtabClProblem Boehm_JProteomeRes2014\
+    \nProblem statistics\n  Parameters to estimate: 9\n  ODE: 8 states, 10 parameters\n  \
+    Observables: 3\n  Simulation conditions: 1\n\nCurriculum statistics (3 stages)\n  \
+    Stage 1: tspan [0.0, 20.0]\n           fraction (obs/cond): 1.0/1.0\n  \
+    Stage 2: tspan [0.0, 80.0]\n           fraction (obs/cond): 1.0/1.0\n  \
     Stage 3: tspan [0.0, 240.0]\n           fraction (obs/cond): 1.0/1.0"
-@test "$(describe(prob_cl2; as_string = true))" == "PEtabClProblem Bachmann_MSB2011\nProblem \
-    statistics\n  Parameters to estimate: 113\n  ODE: 25 states, 39 parameters\n  \
+@test "$(describe(prob_cl2; as_string = true))" == "PEtabClProblem Bachmann_MSB2011\
+    \nProblem statistics\n  Parameters to estimate: 113\n  ODE: 25 states, 39 parameters\n  \
     Observables: 20\n  Simulation conditions: 36\n\nCurriculum statistics (4 stages)\n  \
-    Stage 1: tspan [0.0, 7.0]\n           fraction (obs/cond): 0.5/0.5\n  Stage 2: tspan \
-    [0.0, 20.0]\n           fraction (obs/cond): 0.69/0.8\n  Stage 3: tspan [0.0, \
-    60.0]\n           fraction (obs/cond): 0.86/0.8\n  Stage 4: tspan [0.0, \
-    360.0]\n           fraction (obs/cond): 1.0/1.0"
-
+    Stage 1: tspan [0.0, 7.5]\n           fraction (obs/cond): 0.5/0.5\n  \
+    Stage 2: tspan [0.0, 25.0]\n           fraction (obs/cond): 0.69/0.8\n  \
+    Stage 3: tspan [0.0, 80.0]\n           fraction (obs/cond): 0.86/0.8\n  \
+    Stage 4: tspan [0.0, 360.0]\n           fraction (obs/cond): 1.0/1.0"
 @test "$(describe(prob_ms; as_string = true))" == "PEtabMsProblem Boehm_JProteomeRes2014\
-    \nProblem statistics\n  Parameters to estimate: 9\n  ODE: 8 states, 10 \
-    parameters\n  Observables: 3\n  Simulation conditions: 1\n\nWindow statistics (3 \
-    windows)\n  Penalty λ = 1.0e+00, window u0 parameters: 16\n  Window 1: tspan [0.0, \
-    20.0]\n  Window 2: tspan [20.0, 80.0]\n  Window 3: tspan [80.0, 240.0]"
-
+    \nProblem statistics\n  Parameters to estimate: 9\n  ODE: 8 states, 10 parameters\n  \
+    Observables: 3\n  Simulation conditions: 1\n\nWindow statistics (3 windows)\n  \
+    Penalty λ = 1.0e+00, window u0 parameters: 16\n  Window 1: tspan [0.0, 30.0]\n  \
+    Window 2: tspan [30.0, 100.0]\n  Window 3: tspan [100.0, 240.0]"
 @test "$(describe(prob_cl_ms; as_string = true))" == "PEtabClMsProblem \
     Boehm_JProteomeRes2014\nProblem statistics\n  Parameters to estimate: 9\n  ODE: 8 \
     states, 10 parameters\n  Observables: 3\n  Simulation conditions: 1\n\nCurriculum \
-    statistics (3 stages)\n  Window penalty λ = 1.0e+00\n  Stage 1: window tspans [0, 20], \
-    [20, 80], [80, 240]\n  Stage 2: window tspans [0, 80], [20, 240]\n  Stage 3: \
-    original problem"
+    statistics (3 stages)\n  Window penalty λ = 1.0e+00\n  Stage 1: window tspans \
+    [0, 30], [30, 100], [100, 240]\n  Stage 2: window tspans [0, 100], [30, 240]\n  \
+    Stage 3: original problem"

--- a/test/util.jl
+++ b/test/util.jl
@@ -47,3 +47,10 @@ end
 @test_throws ArgumentError allocate_cl_epochs(6000, 5, 1.2)
 @test_throws ArgumentError allocate_cl_epochs(6000, 5, 0.0)
 @test_throws ArgumentError allocate_cl_epochs(10, 10, 0.3)
+
+# Test that the splitting functions split the data into chunks of approximately equal size
+for n_chunks in [3, 5, 13, 21]
+    c = PEtabTraining._makechunks(collect(1:61), n_chunks)
+    diff = [length(c[i + 1]) - length(c[i]) for i in 1:(length(c) - 1)]
+    @test all(abs.(diff) .≤ 1)
+end


### PR DESCRIPTION
Ensure that number of data-points, or time-points between chunks differ at most by 1. This ensures a smoother progression when, for example, doing curriculum learning such that the problem is not changed to drastically between stages.